### PR TITLE
Use a Serilog template with the message as a property

### DIFF
--- a/src/SerilogCommonLogger.cs
+++ b/src/SerilogCommonLogger.cs
@@ -101,7 +101,7 @@ namespace Common.Logging.Serilog
         {
             var logLevel = this.ConvertLevel(level);
 
-            this._logger.Write(logLevel, exception, message.ToString());
+            this._logger.Write(logLevel, exception, "{message:l}", message.ToString());
         }
 
         /// <summary> Convert level. </summary>


### PR DESCRIPTION
This is to avoid the extra overhead of parsing each logged message and caching
it as described on the documentation page here:
https://github.com/serilog/serilog/wiki/Writing-Log-Events#message-template-recommendations

>    Serilog events have a message template associated, not a message. Internally, Serilog parses and caches every template (up to a fixed size limit). Treating the string parameter to log methods as a message, as in the case below, will degrade performance and consume cache memory.
