### PR TITLE
Allow objects to be logged without destroying their structure

### DIFF
--- a/src/Common.Logging.Serilog.csproj
+++ b/src/Common.Logging.Serilog.csproj
@@ -49,6 +49,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
This pull request is related to logging an Object, rather than a string. For example:
log.Info(myobject); 

I found that this logged just the name of the type, instead of the properties and their values. In other words, the structure of the object was being destroyed, which IMHO is counter to the intention of Serilog.

I traced the problem to method WriteInternal in SerilogCommonLogger.cs, line:
this._logger.Write(logLevel, exception, "{message:l}", message.ToString());

Removing the ToString solves the problem. In my pull request, I added a try-catch so if the logger somehow can't deal with the object and throws an exception, it tries to log the message again, but with ToString applied.

Thanks for creating this project! I'm looking forward to seeing a new version with this fix appear on NuGet, so I can use this package in my current project.

Thanks,

Matt
