### PR TITLE
Allow structured objects to be sent to common logger as JSON strings

### DIFF
--- a/src/Common.Logging.Serilog.csproj
+++ b/src/Common.Logging.Serilog.csproj
@@ -49,6 +49,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SerilogCommonLogger.cs
+++ b/src/SerilogCommonLogger.cs
@@ -20,6 +20,8 @@ namespace Common.Logging.Serilog
 
     using global::Serilog;
     using global::Serilog.Events;
+    using System.Web.Script.Serialization;
+    using System.Collections.Generic;
 
     /// <summary> Serilog common logger. </summary>
     public class SerilogCommonLogger : AbstractLogger
@@ -101,7 +103,38 @@ namespace Common.Logging.Serilog
         {
             var logLevel = this.ConvertLevel(level);
 
-            this._logger.Write(logLevel, exception, "{message:l}", message.ToString());
+            // _logger.Write will happily log both strings and objects.
+            // Objects will be logged without destroying their structure (using "structured" logging).
+            // But just in case, there is a try-catch fallback to convert the message to a string
+            // before trying again to log it.
+            try
+            {
+                // If message is a string, try to deserialize if it might be a JSON object.
+                // If that goes wrong, simply log it as a string.
+                //
+                // This is very useful, because Common.Logging implementations for other logging packages
+                // often do not support logging objects - when given an object, they just log the name of the object.
+                // By including this conversion, software trying to log objects via Common.Logging can
+                // serialise those objects into a JSON string and log that string, knowing that if
+                // Common.Logging.Serilog is used, the object will still be logged in a structured manner.
+
+                if (message is string)
+                {
+                    string messageString = (string)message;
+
+                    if (messageString.TrimStart().StartsWith("{"))
+                    {
+                        JavaScriptSerializer js = new JavaScriptSerializer();
+                        message = js.Deserialize<Dictionary<string, Object>>(messageString);
+                    }
+                }
+
+                this._logger.Write(logLevel, exception, "{message:l}", message);
+            }
+            catch
+            {
+                this._logger.Write(logLevel, exception, "{message:l}", message.ToString());
+            }
         }
 
         /// <summary> Convert level. </summary>


### PR DESCRIPTION
After trying to log structured objects (rather than strings) via other Common.Logging adapters (common.logging.nlog, common.logging.elmah), I found that these simply log the name of the object, discarding all information in the object. So anyone logging via Common.Logging has to serialize their objects into strings before logging them.

However, I would still like to log objects in a structured manner when common.logging.serilog is used, because that is the whole point of serilog. So the code change in this pull request checks whether the log message is a string and also a JSON object, and if so deserializes it so serilog can log it in a structured manner.

This way, someone who has been logging objects as strings can switch to structured logging with common.logging.serilog through configuration, without changing their code. This will make adoption of structured logging much easier when dealing with big code bases.

My pull request only deals with objects serialized to JSON. If an object has been serialized to XML, it will still be logged as a (destructured) string.
