### PR TITLE
[SerilogCommonLogger] Add check for StringFormatFormattedMessage to ensu...

### DIFF
--- a/src/SerilogCommonLogger.cs
+++ b/src/SerilogCommonLogger.cs
@@ -76,7 +76,6 @@ namespace Common.Logging.Serilog
             if (type == typeof(StringFormatFormattedMessage))
             {
                 _logger.Write(logLevel, exception, message.ToString(), null);
-
             }
             else 
             if (message is string) _logger.Write(logLevel, exception, "{Message:l}", message.ToString());


### PR DESCRIPTION
Explanation:

I noticed that if I write a message to Serilog via Common.Logging using a string formatter. the final log message gets written out as "StringFormatFormattedMessage { }" The original log line was something like: 
log.WarnFormat("Test Warning using Common Logging String Formatter. Some value: {0}", 1000);

This then got passed into Serilog as though there was a property, but rather, that property is just the whole String.Format ToStringed, Serilog then can't identify the type correctly in the PropertyValueConverter and it ends up just giving the name of the type as the log line message. This happens in "CreatePropertyValue".

The fix I made means that the log-line is written out just as the ToString() message would output the formatted string. There could be an even better fix, which would send the parameter properly to Serilog, 
however, this would have to change StringFormatFormattedMessage type, which is part of Common.Logging...

Images:
![beforefix](https://cloud.githubusercontent.com/assets/2387904/4435783/88bd74e8-4757-11e4-8cc2-7e730c5cd469.PNG)

![afterfix](https://cloud.githubusercontent.com/assets/2387904/4435784/8da457d8-4757-11e4-96a9-7daacef05b3e.PNG)
