### PR TITLE
Common Logging 3 Basic Support

### DIFF
--- a/src/Common.Logging.Serilog.csproj
+++ b/src/Common.Logging.Serilog.csproj
@@ -33,7 +33,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Common.Logging">
-      <HintPath>..\packages\Common.Logging.2.3.1\lib\net40\Common.Logging.dll</HintPath>
+      <HintPath>..\packages\Common.Logging.3.0.0\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="Serilog">
       <HintPath>..\packages\Serilog.1.4.15\lib\net45\Serilog.dll</HintPath>

--- a/src/SerilogCommonLogger.cs
+++ b/src/SerilogCommonLogger.cs
@@ -617,5 +617,22 @@ namespace Common.Logging.Serilog
             else
                 Write(level, exception, string.Format(formatProvider, message, parameters));
         }
+
+
+        /// <summary>
+        /// Returns the global context for variables
+        /// </summary>
+        public virtual IVariablesContext GlobalVariablesContext
+        {
+            get { return new Simple.NoOpVariablesContext(); }
+        }
+
+        /// <summary>
+        /// Returns the thread-specific context for variables
+        /// </summary>
+        public virtual IVariablesContext ThreadVariablesContext
+        {
+            get { return new Simple.NoOpVariablesContext(); }
+        }
     }
 }

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="2.3.1" targetFramework="net45" />
+  <package id="Common.Logging" version="3.0.0" targetFramework="net45" />
+  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net45" />
   <package id="Serilog" version="1.4.15" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I can't find much in the way of documentation about the changes to Common.Logging 3, presumably documentation of the new release is forthcoming at some point.  From what I can see, the only significant change is the introduction of Global and Thread variables context, which to my understanding are incompatible with Serilog's way of doing things (pushing onto a stack).

Hence this change simply includes a copy of the changes made to AbstractLogger.  The contexts will be ignored.

Fixes #7 