### PR TITLE
Preformat numeric formatted arguments before passing string to Serilogger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ bld/
 *.VisualState.xml
 TestResult.xml
 
+# NCRUNCH
+*.ncrunchproject
+
 # Build Results of an ATL Project
 [Dd]ebugPS/
 [Rr]eleasePS/

--- a/Common.Logging.Serilog.Tests/Common.Logging.Serilog.Tests.csproj
+++ b/Common.Logging.Serilog.Tests/Common.Logging.Serilog.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{03A85FD2-01EB-4A87-AB4D-D0685F0ED262}</ProjectGuid>
+    <ProjectGuid>{E7035ACA-D59B-4CA2-9606-E7634C5D590F}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Common.Logging.Serilog</RootNamespace>
-    <AssemblyName>Common.Logging.Serilog</AssemblyName>
+    <RootNamespace>Common.Logging.Serilog.Tests</RootNamespace>
+    <AssemblyName>Common.Logging.Serilog.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -32,21 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging, Version=3.1.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Common.Logging.3.1.0\lib\net40\Common.Logging.dll</HintPath>
-    </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Common.Logging.Core.3.1.0\lib\net40\Common.Logging.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Serilog.1.5.1\lib\net45\Serilog.dll</HintPath>
-    </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Serilog.1.5.1\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -57,19 +45,26 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CommonLoggingSerilogHelpers.cs" />
-    <Compile Include="SerilogCommonLogger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SerilogFactoryAdapter.cs" />
-    <Compile Include="SerilogInstanceWrapper.cs" />
-    <Compile Include="SerilogPreformatter.cs" />
+    <Compile Include="SerilogPreformatterTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Common.Logging.Serilog.csproj">
+      <Project>{03A85FD2-01EB-4A87-AB4D-D0685F0ED262}</Project>
+      <Name>Common.Logging.Serilog</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Common.Logging.Serilog.Tests/Common.Logging.Serilog.Tests.csproj
+++ b/Common.Logging.Serilog.Tests/Common.Logging.Serilog.Tests.csproj
@@ -32,8 +32,24 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Common.Logging.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.Core.3.1.0\lib\net40\Common.Logging.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.1.5.1\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.1.5.1\lib\net45\Serilog.FullNetFx.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -46,6 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SerilogCommonLoggerTests.cs" />
     <Compile Include="SerilogPreformatterTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Common.Logging.Serilog.Tests/Properties/AssemblyInfo.cs
+++ b/Common.Logging.Serilog.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Common.Logging.Serilog.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Valtech AB")]
+[assembly: AssemblyProduct("Common.Logging.Serilog.Tests")]
+[assembly: AssemblyCopyright("Copyright © Valtech AB 2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3dab1531-5a4e-4683-89f0-da483807678e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Common.Logging.Serilog.Tests/SerilogCommonLoggerTests.cs
+++ b/Common.Logging.Serilog.Tests/SerilogCommonLoggerTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Linq;
+using Moq;
+using NUnit.Framework;
+using Serilog;
+using Serilog.Events;
+
+namespace Common.Logging.Serilog.Tests
+{
+    [TestFixture]
+    public class SerilogCommonLoggerTests
+    {
+        private Mock<ILogger> _seriLogger;
+        private SerilogCommonLogger _commonLogger;
+
+        [SetUp]
+        public void Setup()
+        {
+            _seriLogger = new Mock<ILogger>();
+            _commonLogger = new SerilogCommonLogger(_seriLogger.Object);
+
+            _seriLogger
+                .Setup(l => l.IsEnabled(It.IsAny<LogEventLevel>()))
+                .Returns(true);
+        }
+
+        [Test]
+        public void Should_Leave_String_As_Is_If_Formatted_With_Serilog_Syntax()
+        {
+            /* Setup */
+            const string templateString = "This is a {@serilog} formatted string";
+            const string expectedString = templateString;
+
+            var arg = new { Type = "Serilog"};
+            var expectedArgs = new object[] {arg};
+            _seriLogger
+                .Setup(l => l.Write(
+                        It.IsAny<LogEventLevel>(),
+                        It.IsAny<Exception>(),
+                        expectedString,
+                        expectedArgs
+                    ))
+                .Verifiable();
+
+            /* Test */
+            _commonLogger.DebugFormat(templateString, arg);
+
+            /* Assert */
+            _seriLogger.VerifyAll();
+        }
+
+        [Test]
+        public void Should_Preformat_String_If_Numerical_Formatted()
+        {
+            /* Setup */
+            const string templateString = "This is a {0} formatted string";
+            var arg = "nummeric";
+            var expectedString = string.Format(templateString, arg);
+            
+            _seriLogger
+                .Setup(l => l.Write(
+                        It.IsAny<LogEventLevel>(),
+                        It.IsAny<Exception>(),
+                        expectedString,
+                        It.Is<object[]>(s => !s.Any())
+                    ))
+                .Verifiable();
+
+            /* Test */
+            _commonLogger.DebugFormat(templateString, arg);
+
+            /* Assert */
+            _seriLogger.VerifyAll();
+        }
+
+        [Test]
+        public void Should_Preformat_Numeric_Formatting_But_Leave_Serilog_Formating()
+        {
+            /* Setup */
+            const string templateString = "This is a {0} formatted string with {@serilog} args, too";
+            var args = new object[] { "nummeric", new { type = "Serilog"} };
+            const string expectedString = "This is a nummeric formatted string with {@serilog} args, too";
+
+            _seriLogger
+                .Setup(l => l.Write(
+                        It.IsAny<LogEventLevel>(),
+                        It.IsAny<Exception>(),
+                        expectedString,
+                        It.Is<object[]>(s => s.Count() == 1 && s[0] == args[1])
+                    ))
+                .Verifiable();
+
+            /* Test */
+            _commonLogger.DebugFormat(templateString, args);
+
+            /* Assert */
+            _seriLogger.VerifyAll();
+        }
+    }
+}

--- a/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
+++ b/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
@@ -61,34 +61,7 @@ namespace Common.Logging.Serilog.Tests
             Assert.That(_resultTemplate, Is.EqualTo(expected));
         }
 
-        public class When_Calling_GetIndecesOfNumericalFormatting : SerilogPreformatterTests
         {
-            [Test]
-            public void Should_Return_Empty_List_If_Template_String_Is_Not_Formatted()
-            {
-                /* Setup */
-                const string originalTemplate = "This is a template without any args";
-
-                /* Test */
-                var result = _preformatter.GetIndecesOfNumericalFormatting(originalTemplate);
-
-                /* Assert */
-                Assert.That(result, Is.Empty);
-            }
-
-            [TestCase("A pure numeric string with {0} and {1}.", new[] {0,1})]
-            [TestCase("A pure {@Serilog} formatted string", new int[0])]
-            [TestCase("A mixed string with both {@Seri} and numeric {1} formatting", new[] {1})]
-            [TestCase("A string with {1}, {10} and {100}", new[] {1, 10, 100})]
-            public void Should_Return_Expected_Indeces(string originalTemplate, int[] expectedResult)
-            {
-                /* Setup */
-                /* Test */
-                var result = _preformatter.GetIndecesOfNumericalFormatting(originalTemplate);
-
-                /* Assert */
-                Assert.That(result, Is.EquivalentTo(expectedResult));
-            }
         }
     }
 }

--- a/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
+++ b/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
@@ -6,11 +6,59 @@ namespace Common.Logging.Serilog.Tests
     public class SerilogPreformatterTests
     {
         private SerilogPreformatter _preformatter;
+        private string _resultTemplate;
+        private object[] _resultArgs;
 
         [SetUp]
         public void Setup()
         {
             _preformatter = new SerilogPreformatter();
+            _resultTemplate = string.Empty;
+            _resultArgs = null;
+        }
+
+        [Test]
+        public void Should_Return_Same_Template_String_If_Original_String_Is_Null_Or_Empty()
+        {
+            /* Setup */
+            const string originalTemplate = null;
+
+            /* Test */
+            var result = _preformatter.TryPreformat(originalTemplate, null, out _resultTemplate, out _resultArgs);
+
+            /* Assert */
+            Assert.That(result, Is.True);
+            Assert.That(_resultTemplate, Is.EqualTo(originalTemplate));
+        }
+
+        [Test]
+        public void Should_Return_Same_Template_String_If_No_Args_Provided()
+        {
+            /* Setup */
+            const string originalTemplate = "This is a template without any args";
+            
+            /* Test */
+            var result = _preformatter.TryPreformat(originalTemplate, null, out _resultTemplate, out _resultArgs);
+
+            /* Assert */
+            Assert.That(result, Is.True);
+            Assert.That(_resultTemplate, Is.EqualTo(originalTemplate));
+        }
+
+        [Test]
+        public void Should_Format_Entire_String_If_Only_Numeric_Formatting_Is_Used()
+        {
+            /* Setup */
+            const string originalTemplate = "Look at this,a {0} formatted string!";
+            var args = new object[] {"nicely "};
+            var expected = string.Format(originalTemplate, args);
+
+            /* Test */
+            var result = _preformatter.TryPreformat(originalTemplate, args, out _resultTemplate, out _resultArgs);
+            
+            /* Assert */
+            Assert.That(result, Is.True);
+            Assert.That(_resultTemplate, Is.EqualTo(expected));
         }
     }
 }

--- a/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
+++ b/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
@@ -49,7 +49,7 @@ namespace Common.Logging.Serilog.Tests
         public void Should_Format_Entire_String_If_Only_Numeric_Formatting_Is_Used()
         {
             /* Setup */
-            const string originalTemplate = "Look at this,a {0} formatted string!";
+            const string originalTemplate = "Look at this, a {0} formatted string!";
             var args = new object[] {"nicely "};
             var expected = string.Format(originalTemplate, args);
 
@@ -59,6 +59,35 @@ namespace Common.Logging.Serilog.Tests
             /* Assert */
             Assert.That(result, Is.True);
             Assert.That(_resultTemplate, Is.EqualTo(expected));
+        }
+
+        public class When_Calling_GetIndecesOfNumericalFormatting : SerilogPreformatterTests
+        {
+            [Test]
+            public void Should_Return_Empty_List_If_Template_String_Is_Not_Formatted()
+            {
+                /* Setup */
+                const string originalTemplate = "This is a template without any args";
+
+                /* Test */
+                var result = _preformatter.GetIndecesOfNumericalFormatting(originalTemplate);
+
+                /* Assert */
+                Assert.That(result, Is.Empty);
+            }
+
+            [TestCase("A pure numeric string with {0} and {1}.", new[] {0,1})]
+            [TestCase("A pure {@Serilog} formatted string", new int[0])]
+            [TestCase("A mixed string with both {@Seri} and numeric {1} formatting", new[] {1})]
+            public void Should_Return_Expected_Indeces(string originalTemplate, int[] expectedResult)
+            {
+                /* Setup */
+                /* Test */
+                var result = _preformatter.GetIndecesOfNumericalFormatting(originalTemplate);
+
+                /* Assert */
+                Assert.That(result, Is.EquivalentTo(expectedResult));
+            }
         }
     }
 }

--- a/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
+++ b/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
@@ -79,6 +79,7 @@ namespace Common.Logging.Serilog.Tests
             [TestCase("A pure numeric string with {0} and {1}.", new[] {0,1})]
             [TestCase("A pure {@Serilog} formatted string", new int[0])]
             [TestCase("A mixed string with both {@Seri} and numeric {1} formatting", new[] {1})]
+            [TestCase("A string with {1}, {10} and {100}", new[] {1, 10, 100})]
             public void Should_Return_Expected_Indeces(string originalTemplate, int[] expectedResult)
             {
                 /* Setup */

--- a/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
+++ b/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
@@ -1,0 +1,16 @@
+﻿using NUnit.Framework;
+
+namespace Common.Logging.Serilog.Tests
+{
+    [TestFixture]
+    public class SerilogPreformatterTests
+    {
+        private SerilogPreformatter _preformatter;
+
+        [SetUp]
+        public void Setup()
+        {
+            _preformatter = new SerilogPreformatter();
+        }
+    }
+}

--- a/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
+++ b/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
@@ -61,7 +61,36 @@ namespace Common.Logging.Serilog.Tests
             Assert.That(_resultTemplate, Is.EqualTo(expected));
         }
 
+        [Test]
+        public void Should_Keep_String_Unformatted_If_Serilog_Formatting_Used()
         {
+            /* Setup */
+            const string originalTemplate = "Look at this, a {serilog} formatted string!";
+            var args = new object[] { "serilog" };
+
+            /* Test */
+            var result = _preformatter.TryPreformat(originalTemplate, args, out _resultTemplate, out _resultArgs);
+
+            /* Assert */
+            Assert.That(result, Is.True);
+            Assert.That(_resultTemplate, Is.EqualTo(originalTemplate));
+        }
+
+        [Test]
+        public void Should_Preformat_Numeric_Part_Of_String_But_Keep_Serilog_Formatted_String_And_Arguments()
+        {
+            /* Setup */
+            const string originalTemplate = "This {@string} has {1} numeric match";
+            var args = new object[] { "serilog", "1" };
+            const string expectedTemplate = "This {@string} has 1 numeric match";
+
+
+            /* Test */
+            var result = _preformatter.TryPreformat(originalTemplate, args, out _resultTemplate, out _resultArgs);
+
+            /* Assert */
+            Assert.That(result, Is.True);
+            Assert.That(_resultTemplate, Is.EqualTo(expectedTemplate));
         }
     }
 }

--- a/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
+++ b/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
@@ -91,6 +91,8 @@ namespace Common.Logging.Serilog.Tests
             /* Assert */
             Assert.That(result, Is.True);
             Assert.That(_resultTemplate, Is.EqualTo(expectedTemplate));
+            Assert.That(_resultArgs.Length, Is.EqualTo(1));
+            Assert.That(_resultArgs[0], Is.EqualTo(args[0]));
         }
     }
 }

--- a/Common.Logging.Serilog.Tests/packages.config
+++ b/Common.Logging.Serilog.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+</packages>

--- a/Common.Logging.Serilog.Tests/packages.config
+++ b/Common.Logging.Serilog.Tests/packages.config
@@ -1,4 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Common.Logging.Core" version="3.1.0" targetFramework="net45" />
+  <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="Serilog" version="1.5.1" targetFramework="net45" />
 </packages>

--- a/Common.Logging.Serilog.sln
+++ b/Common.Logging.Serilog.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Logging.Serilog", "src\Common.Logging.Serilog.csproj", "{03A85FD2-01EB-4A87-AB4D-D0685F0ED262}"
 EndProject
@@ -21,6 +21,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Assets", "Assets", "{D6378B
 		content\web.config.transform = content\web.config.transform
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Logging.Serilog.Tests", "Common.Logging.Serilog.Tests\Common.Logging.Serilog.Tests.csproj", "{E7035ACA-D59B-4CA2-9606-E7634C5D590F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,6 +33,10 @@ Global
 		{03A85FD2-01EB-4A87-AB4D-D0685F0ED262}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{03A85FD2-01EB-4A87-AB4D-D0685F0ED262}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{03A85FD2-01EB-4A87-AB4D-D0685F0ED262}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7035ACA-D59B-4CA2-9606-E7634C5D590F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7035ACA-D59B-4CA2-9606-E7634C5D590F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7035ACA-D59B-4CA2-9606-E7634C5D590F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7035ACA-D59B-4CA2-9606-E7634C5D590F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -18,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: InternalsVisibleTo("Common.Logging.Serilog.Tests")]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("f3753a5f-71d4-4fd5-9208-f79beb1de08c")]

--- a/src/SerilogPreformatter.cs
+++ b/src/SerilogPreformatter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Common.Logging.Serilog
@@ -22,17 +23,39 @@ namespace Common.Logging.Serilog
             {
                 return true;
             }
+            
+            var templateBuilder = new StringBuilder(templateString);
+            var numericArgs = new List<object>();
+            var matches = _numericFormattedRegex.Matches(templateString);
 
-            newTemplate = string.Format(templateString, args);
-            newArgs = null;
+            for (var i = 0; i < matches.Count; i++)
+            {
+                var currentMatcher = matches[i];
+                var argPosition = GetArgumentPosition(currentMatcher);
+                var currentArg = args[argPosition];
+
+                templateBuilder.Remove(currentMatcher.Index, currentMatcher.Length);
+                templateBuilder.Insert(currentMatcher.Index, currentArg);
+
+                numericArgs.Add(numericArgs);
+            }
+
+            newTemplate = templateBuilder.ToString();
+            newArgs = args
+                .Except(numericArgs)
+                .ToArray();
+
             return true;
         }
 
+        private static int GetArgumentPosition(Match currentMatcher)
         {
+            var nummeric = currentMatcher.Groups
                     .OfType<Group>()
                     .Skip(1)
                     .First()
                     .Value;
+            return int.Parse(nummeric);
         }
     }
 }

--- a/src/SerilogPreformatter.cs
+++ b/src/SerilogPreformatter.cs
@@ -10,17 +10,16 @@ namespace Common.Logging.Serilog
 
         public bool TryPreformat(string templateString, object[] args, out string newTemplate, out object[] newArgs)
         {
+            newTemplate = templateString;
+            newArgs = args;
+
             if (string.IsNullOrEmpty(templateString))
             {
-                newTemplate = templateString;
-                newArgs = args;
                 return true;
             }
 
             if (args == null || !args.Any())
             {
-                newTemplate = templateString;
-                newArgs = args;
                 return true;
             }
 

--- a/src/SerilogPreformatter.cs
+++ b/src/SerilogPreformatter.cs
@@ -29,20 +29,11 @@ namespace Common.Logging.Serilog
             return true;
         }
 
-        internal IEnumerable<int> GetIndecesOfNumericalFormatting(string templateString)
         {
-            var matches = _numericFormattedRegex.Matches(templateString);
-
-            for (var i = 0; i < matches.Count; i++)
-            {
-                var numericMatch = matches[i].Groups
                     .OfType<Group>()
                     .Skip(1)
                     .First()
                     .Value;
-
-                yield return int.Parse(numericMatch);
-            }
         }
     }
 }

--- a/src/SerilogPreformatter.cs
+++ b/src/SerilogPreformatter.cs
@@ -6,7 +6,7 @@ namespace Common.Logging.Serilog
 {
     public class SerilogPreformatter
     {
-        private readonly Regex _numericFormattedRegex = new Regex(@"{(\d)}", RegexOptions.Compiled);
+        private readonly Regex _numericFormattedRegex = new Regex(@"{(\d{1,})}", RegexOptions.Compiled);
 
         public bool TryPreformat(string templateString, object[] args, out string newTemplate, out object[] newArgs)
         {

--- a/src/SerilogPreformatter.cs
+++ b/src/SerilogPreformatter.cs
@@ -1,9 +1,13 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Common.Logging.Serilog
 {
     public class SerilogPreformatter
     {
+        private readonly Regex _numericFormattedRegex = new Regex(@"{(\d)}", RegexOptions.Compiled);
+
         public bool TryPreformat(string templateString, object[] args, out string newTemplate, out object[] newArgs)
         {
             if (string.IsNullOrEmpty(templateString))
@@ -23,6 +27,22 @@ namespace Common.Logging.Serilog
             newTemplate = string.Format(templateString, args);
             newArgs = null;
             return true;
+        }
+
+        internal IEnumerable<int> GetIndecesOfNumericalFormatting(string templateString)
+        {
+            var matches = _numericFormattedRegex.Matches(templateString);
+
+            for (var i = 0; i < matches.Count; i++)
+            {
+                var numericMatch = matches[i].Groups
+                    .OfType<Group>()
+                    .Skip(1)
+                    .First()
+                    .Value;
+
+                yield return int.Parse(numericMatch);
+            }
         }
     }
 }

--- a/src/SerilogPreformatter.cs
+++ b/src/SerilogPreformatter.cs
@@ -1,6 +1,28 @@
-﻿namespace Common.Logging.Serilog
+﻿using System.Linq;
+
+namespace Common.Logging.Serilog
 {
     public class SerilogPreformatter
     {
+        public bool TryPreformat(string templateString, object[] args, out string newTemplate, out object[] newArgs)
+        {
+            if (string.IsNullOrEmpty(templateString))
+            {
+                newTemplate = templateString;
+                newArgs = args;
+                return true;
+            }
+
+            if (args == null || !args.Any())
+            {
+                newTemplate = templateString;
+                newArgs = args;
+                return true;
+            }
+
+            newTemplate = string.Format(templateString, args);
+            newArgs = null;
+            return true;
+        }
     }
 }

--- a/src/SerilogPreformatter.cs
+++ b/src/SerilogPreformatter.cs
@@ -1,0 +1,6 @@
+﻿namespace Common.Logging.Serilog
+{
+    public class SerilogPreformatter
+    {
+    }
+}

--- a/src/SerilogPreformatter.cs
+++ b/src/SerilogPreformatter.cs
@@ -37,7 +37,7 @@ namespace Common.Logging.Serilog
                 templateBuilder.Remove(currentMatcher.Index, currentMatcher.Length);
                 templateBuilder.Insert(currentMatcher.Index, currentArg);
 
-                numericArgs.Add(numericArgs);
+                numericArgs.Add(currentArg);
             }
 
             newTemplate = templateBuilder.ToString();


### PR DESCRIPTION
Here's a pull-request that solves issue #11 (_Common.Logging + Numeric Formating + ElasticSearch Sink => Nummeric fields in Elastic_). Simply put I've added a class, `SerilogPreformatter.cs`, that evaluates/formats the "numeric styled" arguments, but leaves the "serilog styled" ones.

The unit tests in the new test project `Common.Logging.Serilog.Tests` verifies that the following functionality for the preformatter:

* It evaluates numerically formatted strings
* It leaves serilog formatted string and arguments as-is

I've tried this solution with my local setup (Common Logging -> Serilog -> Elastic) and it works perfect.