### PR TITLE
Iterate through matches from right to left

### DIFF
--- a/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
+++ b/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
@@ -94,5 +94,21 @@ namespace Common.Logging.Serilog.Tests
             Assert.That(_resultArgs.Length, Is.EqualTo(1));
             Assert.That(_resultArgs[0], Is.EqualTo(args[0]));
         }
+
+        [Test]
+        public void Should_Be_Able_To_Correct_Format_Numeric_String_With_Several_Arguments()
+        {
+            /* Setup */
+            const string originalTemplate = "Look at this, a {0} formatted string with {1} arguments!";
+            var args = new object[] { "nicely", "2" };
+            var expected = string.Format(originalTemplate, args);
+
+            /* Test */
+            var result = _preformatter.TryPreformat(originalTemplate, args, out _resultTemplate, out _resultArgs);
+
+            /* Assert */
+            Assert.That(result, Is.True);
+            Assert.That(_resultTemplate, Is.EqualTo(expected));
+        }
     }
 }

--- a/src/SerilogPreformatter.cs
+++ b/src/SerilogPreformatter.cs
@@ -28,7 +28,7 @@ namespace Common.Logging.Serilog
             var numericArgs = new List<object>();
             var matches = _numericFormattedRegex.Matches(templateString);
 
-            for (var i = 0; i < matches.Count; i++)
+            for (var i = matches.Count - 1; i >= 0; i--)
             {
                 var currentMatcher = matches[i];
                 var argPosition = GetArgumentPosition(currentMatcher);


### PR DESCRIPTION
Here's a fix for #13, sorry for the inconvenience. I've added a test that verifies that we format numeric string correctly and again tried it in my local setup and read through the logs thoroughly. This works! 