### PR TITLE
Callback overload doesn't use the preformatter

### DIFF
--- a/Common.Logging.Serilog.Tests/SerilogCommonLoggerTests.cs
+++ b/Common.Logging.Serilog.Tests/SerilogCommonLoggerTests.cs
@@ -99,6 +99,31 @@ namespace Common.Logging.Serilog.Tests
 
 
         [Test]
+        public void Should_Format_When_Using_Callback_Overload()
+        {
+            /* Setup */
+            const string templateString = "This is a {0} formatted string";
+            var arg = "nummeric";
+            var expectedString = string.Format(templateString, arg);
+
+            _seriLogger
+                .Setup(l => l.Write(
+                        It.IsAny<LogEventLevel>(),
+                        It.IsAny<Exception>(),
+                        expectedString,
+                        It.Is<object[]>(s => !s.Any())
+                    ))
+                .Verifiable();
+
+            /* Test */
+            _commonLogger.Debug(f => f(templateString, arg));
+
+            /* Assert */
+            _seriLogger.VerifyAll();
+        }
+
+
+        [Test]
         public void Should_Preformat_When_Using_Callback_Overload()
         {
             /* Setup */

--- a/Common.Logging.Serilog.Tests/SerilogCommonLoggerTests.cs
+++ b/Common.Logging.Serilog.Tests/SerilogCommonLoggerTests.cs
@@ -96,5 +96,30 @@ namespace Common.Logging.Serilog.Tests
             /* Assert */
             _seriLogger.VerifyAll();
         }
+
+
+        [Test]
+        public void Should_Preformat_When_Using_Callback_Overload()
+        {
+            /* Setup */
+            const string templateString = "This is a {0} formatted string with {@serilog} args, too";
+            var args = new object[] { "nummeric", new { type = "Serilog" } };
+            const string expectedString = "This is a nummeric formatted string with {@serilog} args, too";
+
+            _seriLogger
+                .Setup(l => l.Write(
+                        It.IsAny<LogEventLevel>(),
+                        It.IsAny<Exception>(),
+                        expectedString,
+                        It.Is<object[]>(s => s.Count() == 1 && s[0] == args[1])
+                    ))
+                .Verifiable();
+
+            /* Test */
+            _commonLogger.Debug(f => f(templateString, args));
+
+            /* Assert */
+            _seriLogger.VerifyAll();
+        }
     }
 }

--- a/src/SerilogCommonLogger.cs
+++ b/src/SerilogCommonLogger.cs
@@ -562,14 +562,15 @@ namespace Common.Logging.Serilog
         {
             var messageHandler = new FormatMessageHandler(delegate(string message, object[] parameters)
             {
-                string formatted = string.Format(formatProvider, message, parameters);
-
                 if (formatProvider == null)
                     WriteFormat(level, exception, message, parameters);
                 else
+                {
+                    string formatted = string.Format(formatProvider, message, parameters);
                     Write(level, exception, formatted);
+                }
 
-                return formatted;
+                return string.Empty; // Not used
             });
 
             return messageHandler;


### PR DESCRIPTION
Hi!

I noticed that the preformatter isn't used when you call one of the callback overloads:

    // This fails with a System.FormatException
    _log.Debug(f => f("Debug message with {MyParameter}", GetExpensiveParameter()));

Sorry for pushing a PR on you without asking first, but I had to get a fix for this anyway.. Let me know if you want me to improve something!
