### PR TITLE
Do not filter arguments with the same value

### DIFF
--- a/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
+++ b/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
@@ -110,5 +110,22 @@ namespace Common.Logging.Serilog.Tests
             Assert.That(result, Is.True);
             Assert.That(_resultTemplate, Is.EqualTo(expected));
         }
+
+        [TestCase("Two different numbers {Number1} and {Number2}!", new object[] { 0, 1 },
+                  "Two different numbers {Number1} and {Number2}!", new object[] { 0, 1 })]
+        [TestCase("Two duplicate numbers {Number1} and {Number2}!", new object[] { 1, 1 },
+                  "Two duplicate numbers {Number1} and {Number2}!", new object[] { 1, 1 })]
+        [TestCase("Three numbers, only one unique {Number1}, not {1}, and {Number2}!", new object[] { 0, 42, 0 },
+                  "Three numbers, only one unique {Number1}, not 42, and {Number2}!", new object[] { 0, 0 })]
+        public void Should_Be_Able_To_Correct_Format_Duplicate_Arguments(string originalTemplate, object[] args, string expectedResultTemplate, object[] expectedArgs)
+        {
+            /* Test */
+            var result = _preformatter.TryPreformat(originalTemplate, args, out _resultTemplate, out _resultArgs);
+
+            /* Assert */
+            Assert.That(result, Is.True);
+            Assert.That(_resultTemplate, Is.EqualTo(expectedResultTemplate));
+            Assert.That(_resultArgs, Is.EquivalentTo(expectedArgs));
+        }
     }
 }

--- a/src/SerilogPreformatter.cs
+++ b/src/SerilogPreformatter.cs
@@ -25,9 +25,8 @@ namespace Common.Logging.Serilog
             }
             
             var templateBuilder = new StringBuilder(templateString);
-            var numericArgs = new List<object>();
+            var filteredArgs = new List<object>(args);
             var matches = _numericFormattedRegex.Matches(templateString);
-
             for (var i = matches.Count - 1; i >= 0; i--)
             {
                 var currentMatcher = matches[i];
@@ -37,13 +36,11 @@ namespace Common.Logging.Serilog
                 templateBuilder.Remove(currentMatcher.Index, currentMatcher.Length);
                 templateBuilder.Insert(currentMatcher.Index, currentArg);
 
-                numericArgs.Add(currentArg);
+                filteredArgs.RemoveAt(argPosition);
             }
 
             newTemplate = templateBuilder.ToString();
-            newArgs = args
-                .Except(numericArgs)
-                .ToArray();
+            newArgs = filteredArgs.ToArray();
 
             return true;
         }


### PR DESCRIPTION
Hi,

I've stumbled upon an issue with arguments being dropped from the log message. This occurs when multiple arguments have the same value. For instance these examples: 

```c#
logger.InfoFormat("Color ({Red},{Green},{Blue})", 255, 0, 0);
// Color (255,0,{Blue})

logger.InfoFormat("Color ({Red},{Green},{Blue})", 0, 255, 0);
// Color (0,255,{Blue})

logger.InfoFormat("Color ({Red},{Green},{Blue})", 0, 0, 255);
// Color (0,255,{Blue})
```

The issue is caused by the preformatter when it tries to drop unnamed parameters like `{0}`. The original argument list is filtered with `Array.Except()` which [produces the *set* difference of the arrays](https://msdn.microsoft.com/en-us/library/bb300779(v=vs.110).aspx). This causes only unique values to survive and possible shifts arguments to another position in the arguments array.

In this PR I've changed the preformatter to keep duplicate values when necessary. I've also added a couple of tests to verify the new behavior.

If there's anything I can do to help you review/accept this PR, please let me know!

Kind regards,
Arjen