### PR TITLE
Fix IndexOutOfRangeException when numeric args are duplicate or in reverse order

### DIFF
--- a/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
+++ b/Common.Logging.Serilog.Tests/SerilogPreformatterTests.cs
@@ -117,7 +117,11 @@ namespace Common.Logging.Serilog.Tests
                   "Two duplicate numbers {Number1} and {Number2}!", new object[] { 1, 1 })]
         [TestCase("Three numbers, only one unique {Number1}, not {1}, and {Number2}!", new object[] { 0, 42, 0 },
                   "Three numbers, only one unique {Number1}, not 42, and {Number2}!", new object[] { 0, 0 })]
-        public void Should_Be_Able_To_Correct_Format_Duplicate_Arguments(string originalTemplate, object[] args, string expectedResultTemplate, object[] expectedArgs)
+        [TestCase("Reverse order numbers: {1} and {0}!", new object[] { 0, 1 },
+                  "Reverse order numbers: 1 and 0!", new object[0])]
+        [TestCase("Same number twice: {0} and {0}!", new object[] { 0 },
+                  "Same number twice: 0 and 0!", new object[0])]
+        public void Should_Be_Able_To_Correct_Format_Numeric_Arguments(string originalTemplate, object[] args, string expectedResultTemplate, object[] expectedArgs)
         {
             /* Test */
             var result = _preformatter.TryPreformat(originalTemplate, args, out _resultTemplate, out _resultArgs);


### PR DESCRIPTION
Hi,

The change in #18 introduced a regression where an `IndexOutOfRangeException` is thrown when numeric arguments are used multiple time or in reverse order.

For example:

```csharp
logger.InfoFormat("Item #1={1} and #0={0}", 4, 8);
// IndexOutOfRangeException

logger.InfoFormat("Item #0={0} and #0={0}", 4);
// IndexOutOfRangeException
```

In this PR I've changed the preformatter to keep all arguments until preformatting is done. After preformatting all arguments are filtered at once. I've chosen to do the array filtering manually, instead of using LINQ, for performance reasons.

Kind regards,
Arjen