### PR TITLE
#23 Creating a logger by string name breaks serilog MinimumLevel.Override

### DIFF
--- a/src/SerilogFactoryAdapter.cs
+++ b/src/SerilogFactoryAdapter.cs
@@ -65,7 +65,7 @@ namespace Common.Logging.Serilog
         /// </returns>
         public ILog GetLogger(string name)
         {
-            return new SerilogCommonLogger(new SerilogInstanceWrapper(l => l.ForContext("NamedContext", name), _logger));
+            return new SerilogCommonLogger(new SerilogInstanceWrapper(l => l.ForContext("SourceContext", name), _logger));
         }
     }
 }


### PR DESCRIPTION
Creating a logger by string name instead of type breaks serilog MinimumLevel.Override

Changed NamedContext to SourceContext when creating logger with a string name.