### PR TITLE
Apply Version Number to Assembly 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,10 @@ jobs:
       uses: gittools/actions/gitversion/setup@v3.1.11
       with:
         versionSpec: '6.0.x'
-        
+
+    - name: Show GitVersion config
+      run: dotnet-gitversion /showconfig /config gitversion.yml
+
     - name: GitVersion
       id: gitversion
       uses: gittools/actions/gitversion/execute@v3.1.11

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,10 @@ jobs:
       uses: gittools/actions/gitversion/execute@v3.1.11
       with:
         useConfigFile: true
-        updateProjectFiles: true
-        
+
+    - name: GitVersion update project files
+      run: dotnet-gitversion /updateprojectfiles
+
     - name: Pack
       run: dotnet pack -c Release -p:PackageVersion=${{ steps.gitversion.outputs.nuGetVersion }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,20 +21,15 @@ jobs:
         dotnet-version: ${{ matrix.dotnet-version }}
         
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v3.1.11
+      uses: gittools/actions/gitversion/setup@v1.1.1
       with:
-        versionSpec: '6.0.x'
+        versionSpec: '5.x'
         
     - name: GitVersion
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v3.1.11
+      uses: gittools/actions/gitversion/execute@v1.1.1
       with:
         useConfigFile: true
-
-    - name: Determine Version
-      uses: gittools/actions/gitversion/execute@v3.1.11
-      with:
-        updateProjectFiles: true
         
     - name: Pack
       run: dotnet pack -c Release -p:PackageVersion=${{ steps.gitversion.outputs.nuGetVersion }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v3.1.11
       with:
-        versionSpec: '5.x'
+        versionSpec: '6.0.x'
         
     - name: GitVersion
       id: gitversion
@@ -31,11 +31,11 @@ jobs:
       with:
         useConfigFile: true
 
-    - name: GitVersion
-      uses: gittools/actions/gitversion/command@v3.1.11
+    - name: Determine Version
+      uses: gittools/actions/gitversion/execute@v3.1.11
       with:
-        arguments: '/updateassemblyinfo AssemblyInfo.cs /ensureassemblyinfo'
-
+        updateProjectFiles: true
+        
     - name: Pack
       run: dotnet pack -c Release -p:PackageVersion=${{ steps.gitversion.outputs.nuGetVersion }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
       uses: gittools/actions/gitversion/execute@v3.1.11
       with:
         useConfigFile: true
+        updateProjectFiles: true
         
     - name: Pack
       run: dotnet pack -c Release -p:PackageVersion=${{ steps.gitversion.outputs.nuGetVersion }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       id: gitversion
       uses: gittools/actions/gitversion/execute@v3.1.11
       with:
-        updateProjectFiles: true
+        useConfigFile: true
         
     - name: Pack
       run: dotnet pack -c Release -p:PackageVersion=${{ steps.gitversion.outputs.nuGetVersion }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       id: gitversion
       uses: gittools/actions/gitversion/execute@v3.1.11
       with:
-        useConfigFile: true
+        updateProjectFiles: true
         
     - name: Pack
       run: dotnet pack -c Release -p:PackageVersion=${{ steps.gitversion.outputs.nuGetVersion }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         useConfigFile: true
 
     - name: Pack
-      run: dotnet pack -c Release -p:PackageVersion=${{ steps.gitversion.outputs.nuGetVersion }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+      run: dotnet pack -c Release -p:PackageVersion=${{ steps.gitversion.outputs.FullSemVer }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
         
     - name: Publish
       if: github.event_name != 'pull_request' && (github.ref_name == 'master')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,16 +21,21 @@ jobs:
         dotnet-version: ${{ matrix.dotnet-version }}
         
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v1.1.1
+      uses: gittools/actions/gitversion/setup@v3.1.11
       with:
         versionSpec: '5.x'
         
     - name: GitVersion
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v1.1.1
+      uses: gittools/actions/gitversion/execute@v3.1.11
       with:
         useConfigFile: true
-        
+
+    - name: GitVersion
+      uses: gittools/actions/gitversion/command@v3.1.11
+      with:
+        arguments: '/updateassemblyinfo AssemblyInfo.cs /ensureassemblyinfo'
+
     - name: Pack
       run: dotnet pack -c Release -p:PackageVersion=${{ steps.gitversion.outputs.nuGetVersion }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v3.1.11
       with:
-        versionSpec: '6.x'
+        versionSpec: '6.1.x'
         
     - name: GitVersion
       id: gitversion

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,13 +21,13 @@ jobs:
         dotnet-version: ${{ matrix.dotnet-version }}
         
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v1.1.1
+      uses: gittools/actions/gitversion/setup@v3.1.11
       with:
-        versionSpec: '5.x'
+        versionSpec: '6.x'
         
     - name: GitVersion
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v1.1.1
+      uses: gittools/actions/gitversion/execute@v3.1.11
       with:
         useConfigFile: true
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,14 +28,11 @@ jobs:
     - name: Show GitVersion config
       run: dotnet-gitversion /showconfig /config gitversion.yml
 
-    - name: GitVersion
+    - name: Determine GitVersion
       id: gitversion
       uses: gittools/actions/gitversion/execute@v3.1.11
       with:
         useConfigFile: true
-
-    - name: GitVersion update project files
-      run: dotnet-gitversion /updateprojectfiles
 
     - name: Pack
       run: dotnet pack -c Release -p:PackageVersion=${{ steps.gitversion.outputs.nuGetVersion }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v3.1.11
       with:
-        versionSpec: '6.1.x'
+        versionSpec: '6.0.x'
         
     - name: GitVersion
       id: gitversion

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,3 +1,4 @@
+mode: ContinuousDelivery
 branches: {}
 ignore:
   sha: []

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,3 @@
-mode: Mainline
 branches: {}
 ignore:
   sha: []

--- a/src/Common.Logging.Serilog.csproj
+++ b/src/Common.Logging.Serilog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net462;net472;net481;netstandard2.0;net8.0</TargetFrameworks>
 		<LangVersion>12</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -46,7 +46,7 @@
 	<ItemGroup>
 		<PackageReference Include="Common.Logging" Version="3.4.1.0" />
 		<PackageReference Include="Common.Logging.Core" Version="3.4.1.0" />
-		<PackageReference Include="Serilog" Version="3.1.1" />
+		<PackageReference Include="Serilog" Version="4.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Hello,

I would like to submit this PR to address Issue #28.   As described in the issue, it appears that the assembly versioning was dropped in the most recent builds. As such the libraries are defaulting to 1.0.0.0 for File Version and Assembly Version.   

Please take a look at these changes and accept this PR.  I must admit, I was not sure how to properly test this change.  If there is a way to produce a test build, on Github  for a PR,  please send me the instructions and I will do so.   

Otherwise, if you could advise what the proper changes _should be_, that would be great!

Cheers!